### PR TITLE
Update injection, resolve #10.

### DIFF
--- a/src/history.state.js
+++ b/src/history.state.js
@@ -19,13 +19,14 @@ var historyState = function (window) {
 		})
 	}
 	function _inject() {
-		var oldPushState = history.pushState
-		var oldReplaceState = history.replaceState
-		history.pushState = function () {
+		var proto = history.__proto__
+		var oldPushState = proto.pushState
+		var oldReplaceState = proto.replaceState
+		proto.pushState = function () {
 			oldPushState.apply(this, arguments)
 			this.state = arguments[0]
 		}
-		history.replaceState = function () {
+		proto.replaceState = function () {
 			oldReplaceState.apply(this, arguments)
 			this.state = arguments[0]
 		}


### PR DESCRIPTION
请 @hax 看一眼。

在测试过程中遇到了浏览器在 `history` 对象实现上的差异：
- Firefox 使用 `History()` 来构造 `history` 对象，且 `History` 在全局作用域可访问。
- Android 使用 `History()` 来构造 `history` 对象，但 `History` 在全局作用域不可访问。
- iOS 6- 下 `history` 的构造器不详，`history.constructor` 指向 `Object()`。
- iOS 7+ 下 `history` 的构造器不详，`history.constructor` 指向一个叫 `HistoryConstructor` 的内部对象。

这样一来，我又觉得这个 PR 所做的修改不是那么必要了，似乎改实例才是最安全的方式？
